### PR TITLE
fix the instructions for adding the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,9 @@ When azd has finished deploying, you'll see an endpoint URI in the command outpu
 
 1. Select **SSH** from the left menu then, select **Go**.
 
-1. In the SSH terminal, run `python ./scripts/add_data.py  --file="./data/food_items.json"`.
+1. In the SSH terminal, execute the following commands:
+
+    ```bash
+    pip install -e .
+    python ./scripts/add_data.py  --file="./data/food_items.json"
+    ```


### PR DESCRIPTION
# Purpose

This PR fixes the instructions for adding the data from Azure App Service, previously this step was not needed but something in Azure App service environment changed and it's not able to auto detect the quartapp package anymore.
You will need to manually install the package before running the scripts as there is a dependency between them.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

```md
- [x] Yes
- [ ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

```md
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
```
